### PR TITLE
corrected bug: k-points and symmetries in trace.txt should belong to …

### DIFF
--- a/irrep/bandstructure.py
+++ b/irrep/bandstructure.py
@@ -1104,7 +1104,7 @@ class BandStructure:
             f.write(
                 "   ".join(
                     "{0:10.6f}".format(x)
-                    for x in self.spacegroup.refUC.dot(KP.K)
+                    for x in KP.K
                 )
                 + "\n"
             )

--- a/irrep/spacegroup.py
+++ b/irrep/spacegroup.py
@@ -397,8 +397,8 @@ class SymmetryOperation():
 # this method for Bilbao server
 #       refUC - row-vectors, expressing the reference unit cell vectors in terms of the lattice used in calculation
 #        print ( "symmetry # ",self.ind )
-        R = self.rotation_refUC(refUC)
-        t = self.translation_refUC(refUC, shiftUC)
+        R = self.rotation
+        t = self.translation
 #        np.savetxt(stdout,np.hstack( (R,t[:,None])),fmt="%8.5f" )
         S = self.spinor_rotation
         return ("   ".join(" ".join("{0:2d}".format(x) for x in r) for r in R) + "     " + " ".join("{0:10.6f}".format(x) for x in t) + (


### PR DESCRIPTION
Currently, symmetry operations and coordinates of K-points written to the `trace.txt` file are in the conventional setting, while they should be in the primitive setting used for the DFT calculation (`POSCAR`).

This PR corrects this bug. Symmetry operations and K-points in the primitive setting will written to the `trace.txt` file.